### PR TITLE
Add tests for `== default` for value types

### DIFF
--- a/test/CSharpIsNullAnalyzer.Tests/CSIsNull001Tests.cs
+++ b/test/CSharpIsNullAnalyzer.Tests/CSIsNull001Tests.cs
@@ -238,4 +238,21 @@ class Test
 
         await VerifyCS.VerifyCodeFixAsync(source, fixedSource);
     }
+
+    [Fact]
+    public async Task EqualsDefaultValueType_ProducesNoDiagnostic()
+    {
+        string source = @"
+class Test
+{
+    void Method(int o)
+    {
+        if (o == default)
+        {
+        }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(source);
+    }
 }

--- a/test/CSharpIsNullAnalyzer.Tests/CSIsNull002Tests.cs
+++ b/test/CSharpIsNullAnalyzer.Tests/CSIsNull002Tests.cs
@@ -278,4 +278,21 @@ class Test
         await VerifyCS.VerifyCodeFixAsync(source, fixedSource1, CSIsNull002Fixer.IsObjectEquivalenceKey);
         await VerifyCS.VerifyCodeFixAsync(source, fixedSource2, CSIsNull002Fixer.IsNotNullEquivalenceKey);
     }
+
+    [Fact]
+    public async Task NotEqualsDefaultValueType_ProducesNoDiagnostic()
+    {
+        string source = @"
+class Test
+{
+    void Method(int o)
+    {
+        if (o != default)
+        {
+        }
+    }
+}";
+
+        await VerifyCS.VerifyAnalyzerAsync(source);
+    }
 }


### PR DESCRIPTION
They already pass, but the lack of these test cases made be a bit nervous recently since I couldn't readily explain why they _would_ pass.