### PR TITLE
Merge latest Library.Template

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "powershell": {
-      "version": "7.3.4",
+      "version": "7.3.7",
       "commands": [
         "pwsh"
       ]
@@ -15,7 +15,7 @@
       ]
     },
     "dotnet-coverage": {
-      "version": "17.7.2",
+      "version": "17.8.6",
       "commands": [
         "dotnet-coverage"
       ]

--- a/.editorconfig
+++ b/.editorconfig
@@ -32,6 +32,10 @@ indent_size = 2
 indent_size = 2
 indent_style = space
 
+[*.ps1]
+indent_style = space
+indent_size = 4
+
 # Dotnet code style settings:
 [*.{cs,vb}]
 # Sort using and Import directives with System.* appearing first

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,3 +7,7 @@ updates:
   directory: /
   schedule:
     interval: weekly
+  ignore:
+  # This package has unlisted versions on nuget.org that are not supported. Avoid them.
+  - dependency-name: dotnet-format
+    versions: ["6.x", "7.x", "8.x"]

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -3,6 +3,6 @@
   "files.insertFinalNewline": true,
   "files.trimFinalNewlines": true,
   "omnisharp.enableEditorConfigSupport": true,
-  "omnisharp.enableImportCompletion": true,
-  "omnisharp.enableRoslynAnalyzers": true
+  "omnisharp.enableRoslynAnalyzers": true,
+  "dotnet.completion.showCompletionItemsFromUnimportedNamespaces": true
 }

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -5,7 +5,7 @@
     <BaseIntermediateOutputPath>$(RepoRootPath)obj\$([MSBuild]::MakeRelative($(RepoRootPath), $(MSBuildProjectDirectory)))\</BaseIntermediateOutputPath>
     <BaseOutputPath Condition=" '$(BaseOutputPath)' == '' ">$(RepoRootPath)bin\$(MSBuildProjectName)\</BaseOutputPath>
     <PackageOutputPath>$(RepoRootPath)bin\Packages\$(Configuration)\</PackageOutputPath>
-    <LangVersion>latest</LangVersion>
+    <LangVersion>11</LangVersion>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <AnalysisLevel>latest</AnalysisLevel>

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -12,15 +12,15 @@
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" Version="1.1.1" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(TargetRoslynVersion)" />
     <PackageVersion Include="Microsoft.CodeAnalysis" Version="$(TargetRoslynVersion)" />
-    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.6.2" />
-    <PackageVersion Include="xunit.runner.visualstudio" Version="2.4.5" />
-    <PackageVersion Include="xunit" Version="2.4.2" />
+    <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageVersion Include="xunit.runner.visualstudio" Version="2.5.1" />
+    <PackageVersion Include="xunit" Version="2.5.1" />
   </ItemGroup>
   <ItemGroup>
     <GlobalPackageReference Include="DotNetAnalyzers.DocumentationAnalyzers" Version="1.0.0-beta.59" />
     <GlobalPackageReference Include="Nerdbank.GitVersioning" Version="3.6.133" />
     <GlobalPackageReference Include="Nullable" Version="1.3.1" />
-    <GlobalPackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.435" />
+    <GlobalPackageReference Include="StyleCop.Analyzers.Unstable" Version="1.2.0.507" />
   </ItemGroup>
   <ItemGroup>
     <GlobalPackageReference Include="Microsoft.SourceLink.GitHub" Version="1.1.1" />

--- a/azure-pipelines/Get-SymbolFiles.ps1
+++ b/azure-pipelines/Get-SymbolFiles.ps1
@@ -43,8 +43,13 @@ $PDBs |% {
     }
 } |% {
     # Collect the DLLs/EXEs as well.
-    $dllPath = "$($_.Directory)/$($_.BaseName).dll"
-    $exePath = "$($_.Directory)/$($_.BaseName).exe"
+    $rootName = "$($_.Directory)/$($_.BaseName)"
+    if ($rootName.EndsWith('.ni')) {
+        $rootName = $rootName.Substring(0, $rootName.Length - 3)
+    }
+
+    $dllPath = "$rootName.dll"
+    $exePath = "$rootName.exe"
     if (Test-Path $dllPath) {
         $BinaryImagePath = $dllPath
     } elseif (Test-Path $exePath) {

--- a/azure-pipelines/build.yml
+++ b/azure-pipelines/build.yml
@@ -12,7 +12,7 @@ jobs:
     fetchDepth: 0 # avoid shallow clone so nbgv can do its work.
     clean: true
   - template: install-dependencies.yml
-  - script: dotnet tool run nbgv cloud -c
+  - script: dotnet nbgv cloud -c
     displayName: ⚙ Set build number
   - template: dotnet.yml
     parameters:

--- a/src/Directory.Build.props
+++ b/src/Directory.Build.props
@@ -1,4 +1,12 @@
 <Project>
+  <!-- Include and reference README in nuget package, if a README is in the project directory. -->
+  <PropertyGroup>
+    <PackageReadmeFile Condition="Exists('README.md')">README.md</PackageReadmeFile>
+  </PropertyGroup>
+  <ItemGroup>
+    <None Condition="Exists('README.md')" Include="README.md" Pack="true" PackagePath="" />
+  </ItemGroup>
+
   <Import Project="$([MSBuild]::GetPathOfFileAbove($(MSBuildThisFile), $(MSBuildThisFileDirectory)..))" />
 
   <PropertyGroup>


### PR DESCRIPTION
- Fix symbol file selection for R2R outputs
- Bump dotnet-coverage to 17.7.2
- Bump StyleCop.Analyzers.Unstable from 1.2.0.435 to 1.2.0.507 (#207)
- Bump dotnet-coverage from 17.7.2 to 17.7.3 (#208)
- Bump Microsoft.NET.Test.Sdk to 17.6.3
- Bump powershell to 7.3.5
- Automatically include a README.md from the project directory
- Bump xunit.runner.visualstudio from 2.4.5 to 2.5.0 (#210)
- Bump xunit from 2.4.2 to 2.5.0 (#209)
- Remove `tool run` from `dotnet nbgv` invocation
- Dependabot to ignore dotnet-format
- Set tab settings for .ps1 files
- Bump powershell from 7.3.5 to 7.3.6 (#212)
- Bump dotnet-coverage from 17.7.3 to 17.8.0 (#211)
- Bump dotnet-coverage to 17.8.2
- Bump Microsoft.NET.Test.Sdk from 17.6.3 to 17.7.0 (#213)
- Bump Microsoft.NET.Test.Sdk from 17.7.0 to 17.7.1 (#214)
- Bump dotnet-coverage from 17.8.2 to 17.8.4 (#215)
- Align YAML indentation more consistently
- Bump Microsoft.NET.Test.Sdk from 17.7.1 to 17.7.2 (#218)
- Fix typo in comment
- Bump dotnet-coverage to 17.8.6
- Bump xunit from 2.5.0 to 2.5.1 (#219)
- Bump xunit.runner.visualstudio from 2.5.0 to 2.5.1 (#220)
- Bump powershell to 7.3.7
- Fix LangVersion at 11
