### PR TITLE
Fix `!= null` check in compound expression

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -9,7 +9,7 @@
   <ItemGroup>
     <PackageVersion Include="Microsoft.CodeAnalysis.Analyzers" Version="3.3.4" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp" Version="$(TargetRoslynVersion)" />
-    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" Version="1.1.1" />
+    <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" Version="1.1.1" />
     <PackageVersion Include="Microsoft.CodeAnalysis.CSharp.Workspaces" Version="$(TargetRoslynVersion)" />
     <PackageVersion Include="Microsoft.CodeAnalysis" Version="$(TargetRoslynVersion)" />
     <PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />

--- a/src/CSharpIsNullAnalyzer/CSIsNull002.cs
+++ b/src/CSharpIsNullAnalyzer/CSIsNull002.cs
@@ -64,7 +64,7 @@ public class CSIsNull002 : DiagnosticAnalyzer
                             if (ctxt.Operation is IBinaryOperation { OperatorKind: BinaryOperatorKind.NotEquals } binaryOp)
                             {
                                 Location? location = null;
-                                if (binaryOp.RightOperand is IConversionOperation { ConstantValue: { HasValue: true, Value: null } })
+                                if (binaryOp.RightOperand is IConversionOperation { ConstantValue: { HasValue: true, Value: null } } or ILiteralOperation { ConstantValue: { HasValue: true, Value: null } })
                                 {
                                     location = binaryOp.RightOperand.Syntax.GetLocation();
                                     if (binaryOp.Syntax is BinaryExpressionSyntax { OperatorToken: { } operatorLocation, Right: { } right })
@@ -72,7 +72,7 @@ public class CSIsNull002 : DiagnosticAnalyzer
                                         location = ctxt.Operation.Syntax.SyntaxTree.GetLocation(new TextSpan(operatorLocation.SpanStart, right.Span.End - operatorLocation.SpanStart));
                                     }
                                 }
-                                else if (binaryOp.LeftOperand is IConversionOperation { ConstantValue: { HasValue: true, Value: null } })
+                                else if (binaryOp.LeftOperand is IConversionOperation { ConstantValue: { HasValue: true, Value: null } } or ILiteralOperation { ConstantValue: { HasValue: true, Value: null } })
                                 {
                                     location = binaryOp.LeftOperand.Syntax.GetLocation();
                                     if (binaryOp.Syntax is BinaryExpressionSyntax { OperatorToken: { } operatorLocation, Left: { } left })

--- a/test/CSharpIsNullAnalyzer.Tests/CSIsNull002Tests.cs
+++ b/test/CSharpIsNullAnalyzer.Tests/CSIsNull002Tests.cs
@@ -178,6 +178,68 @@ class Test
     }
 
     [Fact]
+    public async Task NotEqualsNullInLargerExpressionInExpressionTree_OffersOneCodeFix()
+    {
+        string source = @"
+using System;
+using System.Linq.Expressions;
+class Test
+{
+    void Method(int o)
+    {
+        bool? b = true;
+        Expression<Func<bool>> e = () => (b [|!= null|] || 3 < 5);
+    }
+}";
+
+        string fixedSource = @"
+using System;
+using System.Linq.Expressions;
+class Test
+{
+    void Method(int o)
+    {
+        bool? b = true;
+        Expression<Func<bool>> e = () => (b is object || 3 < 5);
+    }
+}";
+
+        await VerifyCS.VerifyCodeFixAsync(source, fixedSource, CSIsNull002Fixer.IsObjectEquivalenceKey);
+        await VerifyCS.VerifyCodeFixAsync(source, source, CSIsNull002Fixer.IsNotNullEquivalenceKey); // assert that this fix is not offered.
+    }
+
+    [Fact]
+    public async Task NullNotEqualsInLargerExpressionInExpressionTree_OffersOneCodeFix()
+    {
+        string source = @"
+using System;
+using System.Linq.Expressions;
+class Test
+{
+    void Method(int o)
+    {
+        bool? b = true;
+        Expression<Func<bool>> e = () => ([|null !=|] b || 3 < 5);
+    }
+}";
+
+        string fixedSource = @"
+using System;
+using System.Linq.Expressions;
+class Test
+{
+    void Method(int o)
+    {
+        bool? b = true;
+        Expression<Func<bool>> e = () => (b is object || 3 < 5);
+    }
+}";
+
+        await VerifyCS.VerifyCodeFixAsync(source, fixedSource, CSIsNull002Fixer.IsObjectEquivalenceKey);
+        await VerifyCS.VerifyCodeFixAsync(source, source, CSIsNull002Fixer.IsNotNullEquivalenceKey); // assert that this fix is not offered.
+    }
+
+    [Fact]
     public async Task NotEqualsNullInExpressionTree_TargetTyped_OffersOneCodeFix()
     {
         string source = @"

--- a/test/CSharpIsNullAnalyzer.Tests/CSharpIsNullAnalyzer.Tests.csproj
+++ b/test/CSharpIsNullAnalyzer.Tests/CSharpIsNullAnalyzer.Tests.csproj
@@ -11,7 +11,7 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing.XUnit" />
+    <PackageReference Include="Microsoft.CodeAnalysis.CSharp.CodeFix.Testing" />
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp.Workspaces" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" />
     <PackageReference Include="xunit.runner.visualstudio" />

--- a/test/CSharpIsNullAnalyzer.Tests/Helpers/CSharpCodeFixVerifier`2+Test.cs
+++ b/test/CSharpIsNullAnalyzer.Tests/Helpers/CSharpCodeFixVerifier`2+Test.cs
@@ -4,12 +4,12 @@
 using System.Reflection;
 using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Testing;
-using Microsoft.CodeAnalysis.Testing.Verifiers;
+using Microsoft.CodeAnalysis.Testing;
 using Microsoft.CodeAnalysis.Text;
 
 public static partial class CSharpCodeFixVerifier<TAnalyzer, TCodeFix>
 {
-    public class Test : CSharpCodeFixTest<TAnalyzer, TCodeFix, XUnitVerifier>
+    public class Test : CSharpCodeFixTest<TAnalyzer, TCodeFix, DefaultVerifier>
     {
         public Test()
         {

--- a/test/CSharpIsNullAnalyzer.Tests/Helpers/CSharpCodeFixVerifier`2.cs
+++ b/test/CSharpIsNullAnalyzer.Tests/Helpers/CSharpCodeFixVerifier`2.cs
@@ -6,17 +6,16 @@ using Microsoft.CodeAnalysis.CodeFixes;
 using Microsoft.CodeAnalysis.CSharp.Testing;
 using Microsoft.CodeAnalysis.Diagnostics;
 using Microsoft.CodeAnalysis.Testing;
-using Microsoft.CodeAnalysis.Testing.Verifiers;
 
 public static partial class CSharpCodeFixVerifier<TAnalyzer, TCodeFix>
     where TAnalyzer : DiagnosticAnalyzer, new()
     where TCodeFix : CodeFixProvider, new()
 {
     public static DiagnosticResult Diagnostic()
-        => CSharpCodeFixVerifier<TAnalyzer, TCodeFix, XUnitVerifier>.Diagnostic();
+        => CSharpCodeFixVerifier<TAnalyzer, TCodeFix, DefaultVerifier>.Diagnostic();
 
     public static DiagnosticResult Diagnostic(string diagnosticId)
-        => CSharpCodeFixVerifier<TAnalyzer, TCodeFix, XUnitVerifier>.Diagnostic(diagnosticId);
+        => CSharpCodeFixVerifier<TAnalyzer, TCodeFix, DefaultVerifier>.Diagnostic(diagnosticId);
 
     public static DiagnosticResult Diagnostic(DiagnosticDescriptor descriptor)
         => new DiagnosticResult(descriptor);


### PR DESCRIPTION
At least in expression trees, these were going uncaught.