### PR TITLE
Add support for default(T)

### DIFF
--- a/src/CSharpIsNullAnalyzer.CodeFixes/IsFixer.cs
+++ b/src/CSharpIsNullAnalyzer.CodeFixes/IsFixer.cs
@@ -46,7 +46,7 @@ namespace CSharpIsNullAnalyzer
             where T : ExpressionOrPatternSyntax
         {
             T expressionWithTrivia = expressionOrPattern.WithTriviaFrom(expr.Right);
-            ExpressionSyntax changedExpression = expr.Right is LiteralExpressionSyntax { RawKind: (int)SyntaxKind.NullLiteralExpression or (int)SyntaxKind.DefaultLiteralExpression }
+            ExpressionSyntax changedExpression = expr.Right is LiteralExpressionSyntax { RawKind: (int)SyntaxKind.NullLiteralExpression or (int)SyntaxKind.DefaultLiteralExpression } or DefaultExpressionSyntax
                 ? create(expr.Left, expressionWithTrivia)
                 : create(expr.Right.WithoutTrailingTrivia().WithTrailingTrivia(Space), expressionWithTrivia);
             SyntaxNode updatedSyntaxRoot = syntaxRoot.ReplaceNode(expr, changedExpression);

--- a/src/CSharpIsNullAnalyzer/CSIsNull001.cs
+++ b/src/CSharpIsNullAnalyzer/CSIsNull001.cs
@@ -59,7 +59,7 @@ public class CSIsNull001 : DiagnosticAnalyzer
                             if (ctxt.Operation is IBinaryOperation { OperatorKind: BinaryOperatorKind.Equals } binaryOp)
                             {
                                 Location? location = null;
-                                if (binaryOp.RightOperand is IConversionOperation { ConstantValue: { HasValue: true, Value: null } })
+                                if (binaryOp.RightOperand.IsNullCheck())
                                 {
                                     location = binaryOp.RightOperand.Syntax.GetLocation();
                                     if (binaryOp.Syntax is BinaryExpressionSyntax { OperatorToken: { } operatorLocation, Right: { } right })
@@ -67,7 +67,7 @@ public class CSIsNull001 : DiagnosticAnalyzer
                                         location = ctxt.Operation.Syntax.SyntaxTree.GetLocation(new TextSpan(operatorLocation.SpanStart, right.Span.End - operatorLocation.SpanStart));
                                     }
                                 }
-                                else if (binaryOp.LeftOperand is IConversionOperation { ConstantValue: { HasValue: true, Value: null } })
+                                else if (binaryOp.LeftOperand.IsNullCheck())
                                 {
                                     location = binaryOp.LeftOperand.Syntax.GetLocation();
                                     if (binaryOp.Syntax is BinaryExpressionSyntax { OperatorToken: { } operatorLocation, Left: { } left })
@@ -76,7 +76,7 @@ public class CSIsNull001 : DiagnosticAnalyzer
                                     }
                                 }
 
-                                if (location is object && !binaryOp.IsWithinExpressionTree(linqExpressionType))
+                                if (location is not null && !binaryOp.IsWithinExpressionTree(linqExpressionType))
                                 {
                                     ctxt.ReportDiagnostic(Diagnostic.Create(Descriptor, location));
                                 }

--- a/src/CSharpIsNullAnalyzer/CSIsNull002.cs
+++ b/src/CSharpIsNullAnalyzer/CSIsNull002.cs
@@ -64,7 +64,7 @@ public class CSIsNull002 : DiagnosticAnalyzer
                             if (ctxt.Operation is IBinaryOperation { OperatorKind: BinaryOperatorKind.NotEquals } binaryOp)
                             {
                                 Location? location = null;
-                                if (binaryOp.RightOperand is IConversionOperation { ConstantValue: { HasValue: true, Value: null } } or ILiteralOperation { ConstantValue: { HasValue: true, Value: null } })
+                                if (binaryOp.RightOperand.IsNullCheck())
                                 {
                                     location = binaryOp.RightOperand.Syntax.GetLocation();
                                     if (binaryOp.Syntax is BinaryExpressionSyntax { OperatorToken: { } operatorLocation, Right: { } right })
@@ -72,7 +72,7 @@ public class CSIsNull002 : DiagnosticAnalyzer
                                         location = ctxt.Operation.Syntax.SyntaxTree.GetLocation(new TextSpan(operatorLocation.SpanStart, right.Span.End - operatorLocation.SpanStart));
                                     }
                                 }
-                                else if (binaryOp.LeftOperand is IConversionOperation { ConstantValue: { HasValue: true, Value: null } } or ILiteralOperation { ConstantValue: { HasValue: true, Value: null } })
+                                else if (binaryOp.LeftOperand.IsNullCheck())
                                 {
                                     location = binaryOp.LeftOperand.Syntax.GetLocation();
                                     if (binaryOp.Syntax is BinaryExpressionSyntax { OperatorToken: { } operatorLocation, Left: { } left })
@@ -81,7 +81,7 @@ public class CSIsNull002 : DiagnosticAnalyzer
                                     }
                                 }
 
-                                if (location is object)
+                                if (location is not null)
                                 {
                                     ImmutableDictionary<string, string?> properties = ImmutableDictionary<string, string?>.Empty;
                                     if (!binaryOp.IsWithinExpressionTree(linqExpressionType))

--- a/src/CSharpIsNullAnalyzer/IOperationExtensions.cs
+++ b/src/CSharpIsNullAnalyzer/IOperationExtensions.cs
@@ -4,6 +4,7 @@
 using System.Collections.Immutable;
 using System.Diagnostics.CodeAnalysis;
 using Microsoft.CodeAnalysis;
+using Microsoft.CodeAnalysis.Operations;
 
 namespace CSharpIsNullAnalyzer;
 
@@ -60,4 +61,12 @@ internal static class IOperationExtensions
             return default;
         }
     }
+
+    /// <summary>
+    /// Checks if this <paramref name="operation"/> is a null check.
+    /// </summary>
+    /// <param name="operation">The operation to check.</param>
+    /// <returns><see langword="true"/> if this operation checks for null, <see langword="false"/> otherwise.</returns>
+    internal static bool IsNullCheck(this IOperation operation) =>
+        operation is (IConversionOperation or ILiteralOperation or IDefaultValueOperation) and { ConstantValue: { HasValue: true, Value: null } };
 }

--- a/test/CSharpIsNullAnalyzer.Tests/CSIsNull001Tests.cs
+++ b/test/CSharpIsNullAnalyzer.Tests/CSIsNull001Tests.cs
@@ -240,6 +240,62 @@ class Test
     }
 
     [Fact]
+    public async Task EqualsDefaultKeywordInIfExpression_ProducesDiagnostic()
+    {
+        string source = @"
+class Test
+{
+    void Method(string s)
+    {
+        if (s [|== default(string)|])
+        {
+        }
+    }
+}";
+
+        string fixedSource = @"
+class Test
+{
+    void Method(string s)
+    {
+        if (s is null)
+        {
+        }
+    }
+}";
+
+        await VerifyCS.VerifyCodeFixAsync(source, fixedSource);
+    }
+
+    [Fact]
+    public async Task EqualsDefaultTInIfExpression_ProducesDiagnostic()
+    {
+        string source = @"
+class Test
+{
+    void Method(Test t)
+    {
+        if (t [|== default(Test)|])
+        {
+        }
+    }
+}";
+
+        string fixedSource = @"
+class Test
+{
+    void Method(Test t)
+    {
+        if (t is null)
+        {
+        }
+    }
+}";
+
+        await VerifyCS.VerifyCodeFixAsync(source, fixedSource);
+    }
+
+    [Fact]
     public async Task EqualsDefaultValueType_ProducesNoDiagnostic()
     {
         string source = @"

--- a/test/CSharpIsNullAnalyzer.Tests/CSIsNull002Tests.cs
+++ b/test/CSharpIsNullAnalyzer.Tests/CSIsNull002Tests.cs
@@ -342,6 +342,86 @@ class Test
     }
 
     [Fact]
+    public async Task NotEqualsDefaultKeywordInIfExpression_ProducesDiagnostic()
+    {
+        string source = @"
+class Test
+{
+    void Method(string s)
+    {
+        if (s [|!= default(string)|])
+        {
+        }
+    }
+}";
+
+        string fixedSource1 = @"
+class Test
+{
+    void Method(string s)
+    {
+        if (s is object)
+        {
+        }
+    }
+}";
+
+        string fixedSource2 = @"
+class Test
+{
+    void Method(string s)
+    {
+        if (s is not null)
+        {
+        }
+    }
+}";
+
+        await VerifyCS.VerifyCodeFixAsync(source, fixedSource1, CSIsNull002Fixer.IsObjectEquivalenceKey);
+        await VerifyCS.VerifyCodeFixAsync(source, fixedSource2, CSIsNull002Fixer.IsNotNullEquivalenceKey);
+    }
+
+    [Fact]
+    public async Task NotEqualsDefaultTInIfExpression_ProducesDiagnostic()
+    {
+        string source = @"
+class Test
+{
+    void Method(Test t)
+    {
+        if (t [|!= default(Test)|])
+        {
+        }
+    }
+}";
+
+        string fixedSource1 = @"
+class Test
+{
+    void Method(Test t)
+    {
+        if (t is object)
+        {
+        }
+    }
+}";
+
+        string fixedSource2 = @"
+class Test
+{
+    void Method(Test t)
+    {
+        if (t is not null)
+        {
+        }
+    }
+}";
+
+        await VerifyCS.VerifyCodeFixAsync(source, fixedSource1, CSIsNull002Fixer.IsObjectEquivalenceKey);
+        await VerifyCS.VerifyCodeFixAsync(source, fixedSource2, CSIsNull002Fixer.IsNotNullEquivalenceKey);
+    }
+
+    [Fact]
     public async Task NotEqualsDefaultValueType_ProducesNoDiagnostic()
     {
         string source = @"


### PR DESCRIPTION
Fixes #91 

Also moved checks to see if an operator is a check against null into a single extension method.

The compiler creates different code for `default(string)` vs `default(T)` 