### PR TITLE
Add IQueryable expression tree regression coverage

### DIFF
--- a/test/CSharpIsNullAnalyzer.Tests/CSIsNull002Tests.cs
+++ b/test/CSharpIsNullAnalyzer.Tests/CSIsNull002Tests.cs
@@ -248,6 +248,43 @@ class Test
     }
 
     [Fact]
+    public async Task NotEqualsNullInQueryableLambda_OffersOneCodeFix()
+    {
+        string source = @"
+using System;
+using System.Linq;
+
+class Test
+{
+    IQueryable<Item> Method(IQueryable<Item> items, DateTime? toDate)
+        => items.Where(a => toDate [|!= null|] || a.Date <= toDate);
+}
+
+class Item
+{
+    public DateTime Date { get; set; }
+}";
+
+        string fixedSource = @"
+using System;
+using System.Linq;
+
+class Test
+{
+    IQueryable<Item> Method(IQueryable<Item> items, DateTime? toDate)
+        => items.Where(a => toDate is object || a.Date <= toDate);
+}
+
+class Item
+{
+    public DateTime Date { get; set; }
+}";
+
+        await VerifyCS.VerifyCodeFixAsync(source, fixedSource, CSIsNull002Fixer.IsObjectEquivalenceKey);
+        await VerifyCS.VerifyCodeFixAsync(source, source, CSIsNull002Fixer.IsNotNullEquivalenceKey); // assert that this fix is not offered.
+    }
+
+    [Fact]
     public async Task NotEqualsNullInExpressionTree_TargetTyped_OffersOneCodeFix()
     {
         string source = @"


### PR DESCRIPTION
Expression-tree lambdas cannot use `is not null`, so the code fix must not offer that action for LINQ queries.

Adds a `CSIsNull002` regression using an `IQueryable.Where` predicate with a nullable date guard. It verifies the valid `is object` action remains available while `is not null` is withheld.

Fixes #31