### PR TITLE
Make CSIsNull002 guidance syntax-neutral

### DIFF
--- a/docfx/docs/analyzers/CSIsNull002.md
+++ b/docfx/docs/analyzers/CSIsNull002.md
@@ -10,7 +10,17 @@ if (value != null)
 }
 ```
 
-The code fix replaces the inequality check with pattern syntax:
+The code fixes replace the inequality check with pattern matching (`is`) syntax, which cannot invoke an overloaded inequality operator.
+
+For C# 9 or later, `is not null` is listed first:
+
+```csharp
+if (value is not null)
+{
+}
+```
+
+The `is object` form is also available:
 
 ```csharp
 if (value is object)
@@ -18,4 +28,4 @@ if (value is object)
 }
 ```
 
-Pattern syntax cannot invoke an overloaded inequality operator. It also lets the compiler reject null checks against non-nullable value types.
+For earlier C# language versions, and within expression trees where `is not null` is unsupported, only `is object` is offered. Both forms let the compiler reject null checks against non-nullable value types.

--- a/src/CSharpIsNullAnalyzer.CodeFixes/CSIsNull002Fixer.cs
+++ b/src/CSharpIsNullAnalyzer.CodeFixes/CSIsNull002Fixer.cs
@@ -47,6 +47,7 @@ public class CSIsNull002Fixer : CodeFixProvider
                 BinaryExpressionSyntax? expr = syntaxRoot?.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true).FirstAncestorOrSelf<BinaryExpressionSyntax>();
                 if (expr is not null)
                 {
+                    // Registration order determines the order shown in the code-fix menu.
                     if (context.Document.Project.ParseOptions is CSharpParseOptions { LanguageVersion: >= LanguageVersion.CSharp9 } &&
                         diagnostic.Properties.ContainsKey(CSIsNull002.OfferIsNotNullFixKey))
                     {

--- a/src/CSharpIsNullAnalyzer/Strings.Designer.cs
+++ b/src/CSharpIsNullAnalyzer/Strings.Designer.cs
@@ -79,7 +79,7 @@ namespace CSharpIsNullAnalyzer {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Use `is object` instead of `!= null` for null checks so the compiler can help you avoid testing struct equality to null..
+        ///   Looks up a localized string similar to Use an `is` expression instead of `!= null` for non-null checks so the compiler can help you avoid testing struct equality to null..
         /// </summary>
         internal static string CSIsNull002_MessageFormat {
             get {
@@ -88,7 +88,7 @@ namespace CSharpIsNullAnalyzer {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to Use `is object` for non-null checks.
+        ///   Looks up a localized string similar to Use an `is` expression for non-null checks.
         /// </summary>
         internal static string CSIsNull002_Title {
             get {

--- a/src/CSharpIsNullAnalyzer/Strings.resx
+++ b/src/CSharpIsNullAnalyzer/Strings.resx
@@ -124,9 +124,9 @@
     <value>Use `is null` for null checks</value>
   </data>
   <data name="CSIsNull002_MessageFormat" xml:space="preserve">
-    <value>Use `is object` instead of `!= null` for null checks so the compiler can help you avoid testing struct equality to null.</value>
+    <value>Use an `is` expression instead of `!= null` for non-null checks so the compiler can help you avoid testing struct equality to null.</value>
   </data>
   <data name="CSIsNull002_Title" xml:space="preserve">
-    <value>Use `is object` for non-null checks</value>
+    <value>Use an `is` expression for non-null checks</value>
   </data>
 </root>

--- a/test/CSharpIsNullAnalyzer.Tests/CSIsNull002Tests.cs
+++ b/test/CSharpIsNullAnalyzer.Tests/CSIsNull002Tests.cs
@@ -2,17 +2,23 @@
 // Licensed under the MIT license. See LICENSE file in the project root for full license information.
 
 using CSharpIsNullAnalyzer;
+using Microsoft.CodeAnalysis;
 using Xunit;
 using VerifyCS = CSharpCodeFixVerifier<CSharpIsNullAnalyzer.CSIsNull002, CSharpIsNullAnalyzer.CSIsNull002Fixer>;
 
 public class CSIsNull002Tests
 {
     [Fact]
-    public void HelpLinkPointsToPublishedDocumentation()
+    public void DescriptorUsesNeutralWordingAndPublishedHelpLink()
     {
         var analyzer = new CSIsNull002();
+        DiagnosticDescriptor descriptor = Assert.Single(analyzer.SupportedDiagnostics);
 
-        Assert.Equal("https://aarnott.github.io/CSharpIsNull/docs/analyzers/CSIsNull002.html", Assert.Single(analyzer.SupportedDiagnostics).HelpLinkUri);
+        Assert.Equal("Use an `is` expression for non-null checks", descriptor.Title.ToString());
+        Assert.Equal(
+            "Use an `is` expression instead of `!= null` for non-null checks so the compiler can help you avoid testing struct equality to null.",
+            descriptor.MessageFormat.ToString());
+        Assert.Equal("https://aarnott.github.io/CSharpIsNull/docs/analyzers/CSIsNull002.html", descriptor.HelpLinkUri);
     }
 
     [Fact]
@@ -38,6 +44,14 @@ class Test
 
         await VerifyCS.VerifyCodeFixAsync(source, fixedSource1, CSIsNull002Fixer.IsObjectEquivalenceKey);
         await VerifyCS.VerifyCodeFixAsync(source, fixedSource2, CSIsNull002Fixer.IsNotNullEquivalenceKey);
+
+        var preferredFixTest = new VerifyCS.Test
+        {
+            TestCode = source,
+            FixedCode = fixedSource2,
+            CodeActionIndex = 0,
+        };
+        await preferredFixTest.RunAsync(TestContext.Current.CancellationToken);
     }
 
     [Fact]


### PR DESCRIPTION
Prefer `is not null` in the code-fix menu and document both supported forms.