### PR TITLE
Fix pointer null comparison code fixes

### DIFF
--- a/src/CSharpIsNullAnalyzer.CodeFixes/CSIsNull002Fixer.cs
+++ b/src/CSharpIsNullAnalyzer.CodeFixes/CSIsNull002Fixer.cs
@@ -47,6 +47,12 @@ public class CSIsNull002Fixer : CodeFixProvider
                 BinaryExpressionSyntax? expr = syntaxRoot?.FindNode(diagnostic.Location.SourceSpan, getInnermostNodeForTie: true).FirstAncestorOrSelf<BinaryExpressionSyntax>();
                 if (expr is not null)
                 {
+                    SemanticModel? semanticModel = await context.Document.GetSemanticModelAsync(context.CancellationToken);
+                    ExpressionSyntax operand = expr.Right is LiteralExpressionSyntax { RawKind: (int)SyntaxKind.NullLiteralExpression or (int)SyntaxKind.DefaultLiteralExpression } or DefaultExpressionSyntax
+                        ? expr.Left
+                        : expr.Right;
+                    bool isPointer = semanticModel?.GetTypeInfo(operand, context.CancellationToken).Type is IPointerTypeSymbol;
+
                     // Registration order determines the order shown in the code-fix menu.
                     if (context.Document.Project.ParseOptions is CSharpParseOptions { LanguageVersion: >= LanguageVersion.CSharp9 } &&
                         diagnostic.Properties.ContainsKey(CSIsNull002.OfferIsNotNullFixKey))
@@ -59,12 +65,15 @@ public class CSIsNull002Fixer : CodeFixProvider
                             diagnostic);
                     }
 
-                    context.RegisterCodeFix(
-                        CodeAction.Create(
-                            Strings.CSIsNull002_Fix1Title,
-                            ct => expr.ReplaceBinaryExpressionWithIsExpression(context.Document, syntaxRoot!, ObjectLiteral),
-                            equivalenceKey: IsObjectEquivalenceKey),
-                        diagnostic);
+                    if (!isPointer)
+                    {
+                        context.RegisterCodeFix(
+                            CodeAction.Create(
+                                Strings.CSIsNull002_Fix1Title,
+                                ct => expr.ReplaceBinaryExpressionWithIsExpression(context.Document, syntaxRoot!, ObjectLiteral),
+                                equivalenceKey: IsObjectEquivalenceKey),
+                            diagnostic);
+                    }
                 }
             }
         }

--- a/src/CSharpIsNullAnalyzer/IOperationExtensions.cs
+++ b/src/CSharpIsNullAnalyzer/IOperationExtensions.cs
@@ -68,5 +68,6 @@ internal static class IOperationExtensions
     /// <param name="operation">The operation to check.</param>
     /// <returns><see langword="true"/> if this operation checks for null, <see langword="false"/> otherwise.</returns>
     internal static bool IsNullCheck(this IOperation operation) =>
-        operation is (IConversionOperation or ILiteralOperation or IDefaultValueOperation) and { ConstantValue: { HasValue: true, Value: null } };
+        (operation is IConversionOperation { Operand: { } operand } && operand.IsNullCheck())
+        || (operation is (ILiteralOperation or IDefaultValueOperation) and { ConstantValue: { HasValue: true, Value: null } });
 }

--- a/test/CSharpIsNullAnalyzer.Tests/CSIsNull001Tests.cs
+++ b/test/CSharpIsNullAnalyzer.Tests/CSIsNull001Tests.cs
@@ -107,6 +107,46 @@ class Test
     }
 
     [Fact]
+    public async Task EqualsNullWithVoidPointer_ProducesDiagnostic()
+    {
+        string source = @"
+unsafe class Test
+{
+    bool Method(void* pointer) => pointer [|== null|];
+}";
+
+        string fixedSource = @"
+unsafe class Test
+{
+    bool Method(void* pointer) => pointer is null;
+}";
+
+        await VerifyCS.VerifyCodeFixAsync(source, fixedSource);
+    }
+
+    [Fact]
+    public async Task EqualsNullWithIntPtrPointer_ProducesDiagnostic()
+    {
+        string source = @"
+using System;
+
+unsafe class Test
+{
+    bool Method(IntPtr* pointer) => pointer [|== null|];
+}";
+
+        string fixedSource = @"
+using System;
+
+unsafe class Test
+{
+    bool Method(IntPtr* pointer) => pointer is null;
+}";
+
+        await VerifyCS.VerifyCodeFixAsync(source, fixedSource);
+    }
+
+    [Fact]
     public async Task EqualsInArgument_ProducesDiagnostic()
     {
         string source = @"

--- a/test/CSharpIsNullAnalyzer.Tests/CSIsNull002Tests.cs
+++ b/test/CSharpIsNullAnalyzer.Tests/CSIsNull002Tests.cs
@@ -160,6 +160,29 @@ class Test
     }
 
     [Fact]
+    public async Task NotEqualsNullWithIntPtrPointer_OffersOnlyIsNotNullFix()
+    {
+        string source = @"
+using System;
+
+unsafe class Test
+{
+    bool Method(IntPtr* pointer) => pointer [|!= null|];
+}";
+
+        string fixedSource = @"
+using System;
+
+unsafe class Test
+{
+    bool Method(IntPtr* pointer) => pointer is not null;
+}";
+
+        await VerifyCS.VerifyCodeFixAsync(source, fixedSource, CSIsNull002Fixer.IsNotNullEquivalenceKey);
+        await VerifyCS.VerifyCodeFixAsync(source, source, CSIsNull002Fixer.IsObjectEquivalenceKey);
+    }
+
+    [Fact]
     public async Task NullNotEqualsInArgument_ProducesDiagnostic()
     {
         string source = @"

--- a/test/CSharpIsNullAnalyzer.Tests/Helpers/CSharpCodeFixVerifier`2+Test.cs
+++ b/test/CSharpIsNullAnalyzer.Tests/Helpers/CSharpCodeFixVerifier`2+Test.cs
@@ -21,6 +21,9 @@ public static partial class CSharpCodeFixVerifier<TAnalyzer, TCodeFix>
                 var parseOptions = (CSharpParseOptions)solution.GetProject(projectId)!.ParseOptions!;
                 solution = solution.WithProjectParseOptions(projectId, parseOptions.WithLanguageVersion(LanguageVersion.CSharp9));
 
+                var compilationOptions = (CSharpCompilationOptions)solution.GetProject(projectId)!.CompilationOptions!;
+                solution = solution.WithProjectCompilationOptions(projectId, compilationOptions.WithAllowUnsafe(true));
+
                 return solution;
             });
 


### PR DESCRIPTION
Pointer comparisons with `null` were missed because Roslyn does not surface a constant value on the outer conversion operation. This restores suggestions for `void*` and `IntPtr*` comparisons.

The analyzer now recognizes null literals through conversions. For pointer non-null comparisons, the code fix offers only `is not null`, since `is object` is not valid for pointer operands. Regression coverage includes both pointer types.

Fixes #30